### PR TITLE
Update gitignore and format files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,18 @@
-source/.import/
+
+# Godot-specific ignores
+.import/
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
+
+# System/tool-specific ignores
+.directory
+*~
 assets/
 releases/
 source/levels/demo/

--- a/source/actors/state_machine/states/dash.gd
+++ b/source/actors/state_machine/states/dash.gd
@@ -62,4 +62,3 @@ func process(actor, delta):
 	var collision = actor.get_slide_collision(0)
 	if abs(rad2deg(collision.normal.angle())) > 90:
 		actor.velocity = Vector2(speed * actor.direction, 0)
-	

--- a/source/actors/state_machine/states/state.gd
+++ b/source/actors/state_machine/states/state.gd
@@ -16,4 +16,3 @@ func setup(actor, previous_state):
 	
 func clear(actor):
 	pass
-	

--- a/source/actors/state_machine/states/walk.gd
+++ b/source/actors/state_machine/states/walk.gd
@@ -51,4 +51,3 @@ func process(actor, delta):
 	
 func _on_coyotte_fall_timeout(actor):
 	actor.fall()
-	

--- a/source/actors/state_machine/states/wall.gd
+++ b/source/actors/state_machine/states/wall.gd
@@ -58,4 +58,3 @@ func process(actor, delta):
 		actor.velocity.x += actor.GRAVITY * -sign(normal.x) * 2
 	
 	actor.velocity.x = clamp(actor.velocity.x, -MAX_WALL_SPEED, MAX_WALL_SPEED)
-	


### PR DESCRIPTION
I updated the gitignore to be based on other Godot gitignores. It's useful to keep this in sync even if not everything is directly relevant. For example, opening the project in a C#-enabled version of Godot will generate the `.mono/` folder even if the project doesn't use C# anywhere.

Also, I ran a formatting script, there were a few scripts that didn't end in newlines, now they do.